### PR TITLE
Add Phantom Tide to World

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -146,6 +146,7 @@
 * [Open Camping Map](https://opencampingmap.org) - Worldwide camping sites map.
 * [Every Mountain](http://everymountainintheworld.com) - Map of every mountain peak in the world.
 * [Shadow Map](https://app.shadowmap.org) - See real-time shadows cast by buildings globally.
+* [Phantom Tide](https://phantom.labs.jamessawyer.co.uk/) - Real-time geospatial intelligence map for maritime and airspace monitoring with vessel tracking, flight activity, official notices, environmental context, and satellite detections.
 * [Maps for Free](https://maps-for-free.com) - Free relief maps and other layers.
 * [PlugShare](https://www.plugshare.com) - Electric vehicle charging station map.
 * [Fishery Restricted Areas Map](http://www.fao.org/gfcm/data/maps/fras/en) - Map of fishery restricted areas.


### PR DESCRIPTION
This adds Phantom Tide to the World section.

Disclosure: I maintain Phantom Tide and am submitting it for inclusion.

Repository:
https://github.com/tg12/phantomtide

Live app:
https://phantom.labs.jamessawyer.co.uk

Why it fits:
Phantom Tide is a real-time geospatial intelligence map with global maritime and airspace coverage. It combines vessel tracking, flight activity, official notices, environmental context, and satellite detections in a single live interface.
