### PR TITLE
Add Hantascan health map

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,7 @@
 * [Cyber Threat Live Map](#cyber-threat-live-map)
 * [Environment](#environment)
 * [Future](#future)
+* [Health](#health)
 * [History](#history)
 * [Marine](#marine)
 * [Music](#music)
@@ -62,6 +63,10 @@
 
 * [FutureTimeline](https://www.futuretimeline.net) - Browse how the future can be.
 * [Earth 2050](https://2050.earth) - A glimpse into the future.
+
+## Health
+
+* [Hantascan](https://hantascan.com) - Live global hantavirus map with reported cases, deaths, country totals, and outbreak locations.
 
 ## History
 


### PR DESCRIPTION
## Summary
- Add a Health section with Hantascan as a live global hantavirus map resource.
- The entry follows the existing map/data website format.

## Test plan
- Documentation-only change; not run.


Made with [Cursor](https://cursor.com)