### PR TITLE
Add Crime Brasil to Others (Brazil neighborhood-level crime map)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -178,6 +178,7 @@
 * [Tip of My Tongue](https://chir.ag/projects/tip-of-my-tongue) - Helps find words that you can't remember.
 * [Fav Icon Map](https://iconmap.io) - Collection of website favicons displayed on a map.
 * [Hoodmaps](https://hoodmaps.com) - User-generated neighborhood maps.
+* [Crime Brasil](https://crimebrasil.com.br) - Interactive crime-data map for Brazil with neighborhood-level incidents (RS bairros, MG/RJ municipal aggregates) and free public API.
 * [Periodic Table Of Tools](https://periodictableoftools.com/index.html) - Periodic Table of Tools
 * [Why Expensive](https://www.why-expensive.com/) - Google search for “why is/are … so expensive” in any language in each country and year between 2012 and 2023
 


### PR DESCRIPTION
Adds [Crime Brasil](https://crimebrasil.com.br) — an open crime-data platform for Brazil — to the most thematically-relevant section of this list.

**Dataset scope:**
- Rio Grande do Sul: 2.99M individual crime records 2022–2026, bairro-level granularity across 497 municipalities + 79K neighborhoods, ~99.99% geocoded
- Minas Gerais: ~965K violent crime records (municipality-level aggregates, SEJUSP)
- Rio de Janeiro: ~37K ISP/CISP records (municipality-level)
- National: PRF DATATRAN (federal highway accidents 2020–2026) + DATASUS SINAN (interpersonal violence 2009–2024)

**Access:** Free public REST API, CSV/Parquet exports, daily incremental updates, CC BY 4.0 license. Documentation at https://crimebrasil.com.br/api/docs.

Disclosure: I'm the maintainer of Crime Brasil.